### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/spotpilot/grid-tariffs/compare/grid-tariffs-v0.1.0...grid-tariffs-v0.2.0) - 2025-09-15
+
+### Fixed
+
+- [**breaking**] Use symmetric FromStr and Display values
+
+### Other
+
+- release-plz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,7 +541,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "grid-tariffs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 
 [package]
 name = "grid-tariffs"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "MIT"
 description = "Grid tariffs"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-grid-tariffs = { version = "0.1.0", path = "../", features = ["schemars"]}
+grid-tariffs = { version = "0.2.0", path = "../", features = ["schemars"]}
 anyhow = "1.0.99"
 clap = { version = "4.5.45", features = ["env", "derive"] }
 directories = "6.0.0"


### PR DESCRIPTION



## 🤖 New release

* `grid-tariffs`: 0.1.0 -> 0.2.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/spotpilot/grid-tariffs/compare/grid-tariffs-v0.1.0...grid-tariffs-v0.2.0) - 2025-09-15

### Fixed

- [**breaking**] Use symmetric FromStr and Display values

### Other

- release-plz
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).