### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/spotpilot/grid-tariffs/compare/grid-tariffs-v0.3.0...grid-tariffs-v0.4.0) - 2025-10-01
+
+### Added
+
+- Add info translations for simplified structs
+- *(SE Hoganas)* Add basic info ([#127](https://github.com/spotpilot/grid-tariffs/pull/127))
+
+### Fixed
+
+- [**breaking**] Don't use tagged serde enums - problem to use with openapi-generator
+
+### Other
+
+- Update package name in CI as well
+
 ## [0.3.0](https://github.com/spotpilot/grid-tariffs/compare/grid-tariffs-v0.2.0...grid-tariffs-v0.3.0) - 2025-09-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,7 +541,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "grid-tariffs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ schemars = { version = "0.9", default-features = false, features = ["derive", "c
 
 [package]
 name = "grid-tariffs"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "MIT"
 description = "Grid tariffs"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-grid-tariffs = { version = "0.3.0", path = "../", features = ["schemars"]}
+grid-tariffs = { version = "0.4.0", path = "../", features = ["schemars"]}
 serde.workspace = true
 chrono.workspace = true
 schemars.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `grid-tariffs`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `grid-tariffs` breaking changes

```text
--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field info of variant TransferFeeSimplified::SpotPriceVariable in /tmp/.tmpXw17aL/grid-tariffs/src/transfer_fee.rs:96

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/method_parameter_count_changed.ron

Failed in:
  grid_tariffs::GridOperator::simplified now takes 4 parameters instead of 3, in /tmp/.tmpXw17aL/grid-tariffs/src/operator.rs:98
  grid_tariffs::PriceList::simplified now takes 4 parameters instead of 3, in /tmp/.tmpXw17aL/grid-tariffs/src/price_list.rs:57
  grid_tariffs::FeedInRevenue::simplified now takes 4 parameters instead of 3, in /tmp/.tmpXw17aL/grid-tariffs/src/revenues.rs:38
  grid_tariffs::PowerTariff::simplified now takes 4 parameters instead of 3, in /tmp/.tmpXw17aL/grid-tariffs/src/power_tariffs.rs:48
  grid_tariffs::TransferFee::simplified now takes 4 parameters instead of 3, in /tmp/.tmpXw17aL/grid-tariffs/src/transfer_fee.rs:48
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/spotpilot/grid-tariffs/compare/grid-tariffs-v0.3.0...grid-tariffs-v0.4.0) - 2025-10-01

### Added

- Add info translations for simplified structs
- *(SE Hoganas)* Add basic info ([#127](https://github.com/spotpilot/grid-tariffs/pull/127))

### Fixed

- [**breaking**] Don't use tagged serde enums - problem to use with openapi-generator

### Other

- Update package name in CI as well
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).