### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/spotpilot/grid-tariffs/compare/grid-tariffs-v0.4.0...grid-tariffs-v0.4.1) - 2025-10-01
+
+### Fixed
+
+- Didn't support passing in English as language
+
 ## [0.4.0](https://github.com/spotpilot/grid-tariffs/compare/grid-tariffs-v0.3.0...grid-tariffs-v0.4.0) - 2025-10-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,7 +541,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "grid-tariffs"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ schemars = { version = "0.9", default-features = false, features = ["derive", "c
 
 [package]
 name = "grid-tariffs"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "MIT"
 description = "Grid tariffs"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-grid-tariffs = { version = "0.4.0", path = "../", features = ["schemars"]}
+grid-tariffs = { version = "0.4.1", path = "../", features = ["schemars"]}
 serde.workspace = true
 chrono.workspace = true
 schemars.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `grid-tariffs`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/spotpilot/grid-tariffs/compare/grid-tariffs-v0.4.0...grid-tariffs-v0.4.1) - 2025-10-01

### Fixed

- Didn't support passing in English as language
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).