### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/spotpilot/grid-tariffs/compare/grid-tariffs-v0.4.2...grid-tariffs-v0.5.0) - 2025-10-02
+
+### Fixed
+
+- Feed-in revenue info wasn't being added...
+- Don't allow None-values for TransferFeeSimplified
+- [**breaking**] Feed-in revenue simplified info + format change
+- Rename module to feed_in_revenue
+
 ## [0.4.2](https://github.com/spotpilot/grid-tariffs/compare/grid-tariffs-v0.4.1...grid-tariffs-v0.4.2) - 2025-10-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,7 +541,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "grid-tariffs"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ schemars = { version = "0.9", default-features = false, features = ["derive", "c
 
 [package]
 name = "grid-tariffs"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 license = "MIT"
 description = "Grid tariffs"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-grid-tariffs = { version = "0.4.2", path = "../", features = ["schemars"]}
+grid-tariffs = { version = "0.5.0", path = "../", features = ["schemars"]}
 serde.workspace = true
 chrono.workspace = true
 schemars.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `grid-tariffs`: 0.4.2 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `grid-tariffs` breaking changes

```text
--- failure enum_struct_variant_changed_kind: An enum struct variant changed kind ---

Description:
A pub enum's struct variant with at least one pub field has changed to a different kind of enum variant, breaking access to its pub fields.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_struct_variant_changed_kind.ron

Failed in:
  variant FeedInRevenueSimplified::Periods in /tmp/.tmpfTeoLQ/grid-tariffs/src/feed_in_revenue.rs:66

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field info of variant FeedInRevenueSimplified::SpotPriceVariable in /tmp/.tmpfTeoLQ/grid-tariffs/src/feed_in_revenue.rs:64
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/spotpilot/grid-tariffs/compare/grid-tariffs-v0.4.2...grid-tariffs-v0.5.0) - 2025-10-02

### Fixed

- Feed-in revenue info wasn't being added...
- Don't allow None-values for TransferFeeSimplified
- [**breaking**] Feed-in revenue simplified info + format change
- Rename module to feed_in_revenue
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).